### PR TITLE
added patch for endian issue

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-melodic-cv-bridge
 	pkgdesc = ROS - This contains CvBridge, which converts between ROS Image messages and OpenCV images.
 	pkgver = 1.13.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://www.wiki.ros.org/cv_bridge
 	arch = any
 	license = BSD
@@ -21,7 +21,9 @@ pkgbase = ros-melodic-cv-bridge
 	depends = python-numpy
 	depends = opencv3-opt
 	source = ros-melodic-cv-bridge-1.13.0.tar.gz::https://github.com/ros-perception/vision_opencv/archive/1.13.0.tar.gz
+	source = endian-fix.patch
 	sha256sums = c8db35dbb6b470cdedb45195f725bc2cfda7f0dc3155e16a5a37e4b48e29fa59
+	sha256sums = bc06dbe12f26015c6bce73b2c95123851415d5662c17ef87267737dd433bb22b
 
 pkgname = ros-melodic-cv-bridge
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,7 +7,7 @@ pkgname='ros-melodic-cv-bridge'
 pkgver='1.13.0'
 _pkgver_patch=0
 arch=('any')
-pkgrel=1
+pkgrel=2
 license=('BSD')
 
 ros_makedepends=(
@@ -40,8 +40,15 @@ depends=(
 )
 
 _dir="vision_opencv-${pkgver}/cv_bridge"
-source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/ros-perception/vision_opencv/archive/${pkgver}.tar.gz")
-sha256sums=('c8db35dbb6b470cdedb45195f725bc2cfda7f0dc3155e16a5a37e4b48e29fa59')
+source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/ros-perception/vision_opencv/archive/${pkgver}.tar.gz"
+  "endian-fix.patch")
+sha256sums=('c8db35dbb6b470cdedb45195f725bc2cfda7f0dc3155e16a5a37e4b48e29fa59'
+  'bc06dbe12f26015c6bce73b2c95123851415d5662c17ef87267737dd433bb22b')
+
+prepare() {
+  cd "${srcdir}/${_dir}"
+  patch -uN src/module.hpp ../../../endian-fix.patch || return 1
+}
 
 build() {
 	# Use ROS environment variables.

--- a/endian-fix.patch
+++ b/endian-fix.patch
@@ -1,0 +1,10 @@
+--- module.hpp.old	2019-09-28 13:24:21.148153374 -0500
++++ module.hpp	2019-09-28 13:23:55.294215002 -0500
+@@ -37,6 +37,7 @@
+ static int do_numpy_import( )
+ {
+     import_array( );
++    return NULL;
+ }
+ #else
+ static void do_numpy_import( )


### PR DESCRIPTION
Adds patch replicating [upstream #292](https://github.com/ros-perception/vision_opencv/pull/292) until it's released.